### PR TITLE
[Docs] 이슈 템플릿 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,23 @@
+name: "Bug"
+description: "버그 제보"
+labels: ["bug"]
+body:
+  - type: textarea
+    attributes:
+      label: 설명
+      description: 어떤 문제가 발생했는지 간단히 설명해주세요
+      placeholder:
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 재현 방법
+      description: 어떤 순서로 재현할 수 있는지 작성해주세요
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 스크린샷 / 로그
+      description: 가능하면 스크린샷이나 로그를 첨부해주세요
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,24 @@
+name: "Chore"
+description: "설정, 스타일 규칙, 디자인 시스템 등 유지보수 작업"
+labels: ["chore"]
+body:
+  - type: textarea
+    attributes:
+      label: 설명
+      description: 해당 작업이 필요한 배경과 목적을 설명해주세요.
+      placeholder: 왜 이 작업이 필요한지, 어떤 문제를 해결하려는지 적어주세요.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 작업 항목
+      description: 수행할 작업을 체크박스 형태로 작성해주세요.
+      placeholder: 최대한 세분화 해서 적어주세요!
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 고려 사항
+      description: 작업 시 주의해야 할 점이나 팀 내 합의가 필요한 부분을 작성해주세요.
+      placeholder: 예) text-sm의 의미 변경, 기존 컴포넌트 영향 범위 등

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -1,0 +1,22 @@
+name: "Feat"
+description: "새로운 기능 추가"
+labels: ["feat"]
+body:
+  - type: textarea
+    attributes:
+      label: 설명
+      description: 새로운 기능에 대한 설명을 작성해 주세요.
+      placeholder: 자세히 적을수록 좋습니다!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 작업할 내용
+      description: 할 일을 체크박스 형태로 작성해주세요.
+      placeholder: 최대한 세분화 해서 적어주세요!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 참고 자료
+      description: 참고 자료가 있다면 작성해 주세요.

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -1,0 +1,17 @@
+name: "Fix"
+description: "버그 수정"
+labels: ["fix"]
+body:
+  - type: textarea
+    attributes:
+      label: 설명
+      description: 오타, 잘못된 설정, 누락된 주석 등 사소한 수정을 설명해주세요
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 작업 항목
+      description: 할 일을 체크박스 형태로 작성해주세요.
+      placeholder: 최대한 세분화 해서 적어주세요!
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,22 @@
+name: "Refactor"
+description: "코드 / 구조 리팩토링"
+labels: ["refactor"]
+body:
+  - type: textarea
+    attributes:
+      label: 설명
+      description: 리팩토링이 필요한 이유를 설명해주세요.
+      placeholder: 자세히 적을수록 좋습니다!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 리팩토링 항목
+      description: 할 일을 체크박스 형태로 작성해주세요.
+      placeholder: 최대한 세분화 해서 적어주세요!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 고려 사항
+      description: 리팩토링 시 주의해야 할 점이 있다면 작성해주세요

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -1,0 +1,22 @@
+name: "Test"
+description: "테스트 코드 작성 / 개선"
+labels: ["test"]
+body:
+  - type: textarea
+    attributes:
+      label: 설명
+      description: 어떤 테스트를 추가/개선할지 설명해주세요
+      placeholder: 자세히 적을수록 좋습니다!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 작업할 테스트
+      description: 할 일을 체크박스 형태로 작성해주세요.
+      placeholder: 최대한 세분화 해서 적어주세요!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 참고 사항
+      description: mock 처리, 테스트 전략 등 기술적인 설명이 있다면 작성해주세요


### PR DESCRIPTION
## 변경 사항
- GitHub 이슈 관리를 표준화하기 위해 이슈 템플릿을 추가했습니다.
- 작업 유형에 따라 Feat / Bug / Fix / Refactor / Chore / Test 템플릿을 제공합니다.

## 목적
- 이슈 생성 시 필요한 정보(배경, 작업 항목 등)를 구조화하여
  작업 범위를 명확히 하고 협업 시 혼선을 줄이기 위함입니다.
- 이슈 타입에 따라 라벨이 자동으로 부착되도록 설정했습니다.

## 적용 범위
- `.github/ISSUE_TEMPLATE/`
  - feat.yml
  - bug.yml
  - fix.yml
  - refactor.yml
  - chore.yml
  - test.yml

## 참고 사항
- 문서/프로세스 정비 성격의 작업으로 별도 이슈 없이 docs 브랜치에서 진행했습니다.
- 기능 및 코드 로직에는 영향이 없습니다.