### PR TITLE
[CHORE] deploy.yml 권한 설정 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: read
 
     outputs:
       image_tag: ${{ needs.prepare.outputs.head_sha }}


### PR DESCRIPTION
build-image Job 아티팩트 다운로드 403 에러 해결
actions: read 권한 명시적 추가

## 📝 변경 사항

- `.github/workflows/deploy.yml` 파일의 `build-image` Job에 `permissions` 설정을 수정했습니다.
- `actions: read` 권한을 명시적으로 추가했습니다.

## 🎯 목적

- `build-image` Job에서 GHCR 업로드를 위해 `packages: write` 권한을 설정함에 따라, 기본 권한이 초기화되어 아티팩트 다운로드(`actions/download-artifact`) 시 403(Forbidden) 에러가 발생했습니다.
- 아티팩트 접근 권한(`actions: read`)을 추가하여, 이전 단계에서 생성된 빌드 결과물(`dist`)을 정상적으로 다운로드하고 Docker 이미지를 빌드할 수 있도록 수정했습니다.

## 📂 적용 범위

- `.github/workflows/deploy.yml`

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [X] Merge 대상 브랜치가 올바른가?
- [X] 코드가 정상적으로 빌드되는가?
- [X] 최종 코드가 에러 없이 잘 동작하는가?
- [X] 전체 변경사항이 500줄을 넘지 않는가?
- [ ] 관련 테스트 코드를 작성했는가?
- [X] 기존 테스트가 모두 통과하는가?
- [X] 코드 스타일(ESLint, Prettier)을 준수하는가?