### PR TITLE
[Feat] OAuth 로그인 환경별 분기 처리 구현

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -5,6 +5,11 @@ function openExternalInKakao(url: string) {
   window.location.href = externalUrl;
 }
 
+function buildGoogleOauthUrl(baseUrl?: string) {
+  const base = String(baseUrl ?? '').replace(/\/+$/, '');
+  return base ? `${base}/oauth2/authorization/google` : '';
+}
+
 export default function LoginPage() {
   const BACKEND_API_BASE_URL = import.meta.env.VITE_BACKEND_API_BASE_URL as string | undefined;
 
@@ -18,11 +23,7 @@ export default function LoginPage() {
   // 인앱 브라우저의 경우 버튼 클릭 유도
   const [showFallback, setShowFallback] = useState<boolean>(() => isInApp);
 
-  const oauthUrl = (() => {
-    const base = String(BACKEND_API_BASE_URL ?? '').replace(/\/+$/, '');
-    if (!base) return '';
-    return `${base}/oauth2/authorization/google`;
-  })();
+  const oauthUrl = buildGoogleOauthUrl(BACKEND_API_BASE_URL);
 
   const startLogin = useCallback(() => {
     if (!oauthUrl) return;
@@ -41,13 +42,11 @@ export default function LoginPage() {
 
     if (isInApp) return;
 
+    startLogin();
     if (isIOS) {
-      startLogin();
       const t = window.setTimeout(() => setShowFallback(true), 800);
       return () => window.clearTimeout(t);
     }
-
-    startLogin();
   }, [oauthUrl, isInApp, isIOS, startLogin]);
 
   if (!oauthUrl) {


### PR DESCRIPTION
## 🍀 이슈 번호

- closed: #66

---

## 📝 변경 사항
- 카카오톡 인앱 브라우저에서 Google OAuth 로그인 시 자동 리다이렉트/팝업이 동작하지 않는 문제를 대응하기 위해 `/login` 페이지 로그인 플로우를 개선했습니다.
- User-Agent 기반 환경 감지 로직을 추가했습니다.
  - iOS(Safari) 감지 (`iPhone|iPad|iPod`)
  - 카카오톡 인앱 브라우저 감지 (`KAKAOTALK`)
  - 기타 인앱 브라우저 감지 (Instagram/FB/Line/Naver in-app 등)
- iOS Safari 환경에서는 **자동 리다이렉트를 우선 시도**하고, 실패 가능성을 대비해 **fallback UI를 노출**하도록 처리했습니다.
  - 페이지 진입 시 `startLogin()`으로 자동 이동 시도
  - `setTimeout(800ms)` 이후 fallback 문구/버튼 노출
- 카카오톡 인앱 브라우저에서는 **외부 브라우저로 강제 전환** 후 OAuth를 진행하도록 처리했습니다.
  - `kakaotalk://web/openExternal?url=...` 스킴 사용
  - 버튼 클릭(사용자 제스처) 기반으로만 실행되도록 구성
- 기타 인앱 브라우저에서는 자동 리다이렉트를 차단하고, 버튼 클릭 기반 로그인으로 안정성을 확보했습니다.
  - `isInApp`이면 `useEffect`에서 자동 리다이렉트 시도하지 않음
  - 최초 렌더 시 `showFallback` 초기값을 `isInApp`로 설정하여 즉시 안내 노출
- 로그인 트리거 로직을 `startLogin()`으로 정리하고, 환경별 분기를 내부로 통합했습니다.
- 로그인 안내 문구 UX를 개선했습니다(카카오 인앱/자동 실패/fallback/기본 상태 분기).

## 🎯 목적

- 카카오톡 인앱 브라우저(iOS 포함)에서 Google OAuth가 정상적으로 진행되지 않는 이슈를 해결하여, 지원자 로그인 경험을 안정화합니다.
- iOS 및 인앱 브라우저의 리다이렉트 제한 정책을 고려해 **자동 시도 + 실패 시 버튼 유도** 방식으로 UX를 개선하고, 로그인 성공률을 높입니다.
- 환경별 분기 처리를 명확히 하여 유지보수성과 디버깅 편의성을 확보합니다.

## 📂 적용 범위

- `src/pages/login/index.tsx`
  - User-Agent 기반 환경 감지 및 리다이렉트 분기 처리
  - 카카오 인앱 외부 브라우저 전환 처리
  - iOS 자동 리다이렉트 + fallback UI 처리
  - 안내 문구 UX 분기 처리
- (테스트/로컬 설정) `vite.config.ts`
  - Cloudflare Tunnel 테스트를 위한 `server.allowedHosts` 설정 점검/반영(필요 시)
  - 
---

## 💬 리뷰어에게

	•	카카오톡 인앱 브라우저에서는 자동 리다이렉트/팝업이 제한되는 특성상, kakaotalk://web/openExternal 스킴을 버튼 클릭 기반으로 실행하도록 구성했습니다.
	•	iOS Safari는 자동 리다이렉트가 케이스에 따라 막힐 수 있어, 자동 시도 후 fallback UI를 노출하는 UX로 설계했습니다.
	•	Cloudflare Tunnel 기반으로 인앱 환경에서 실제 동작을 테스트할 수 있도록 로컬 테스트 플로우를 함께 점검했습니다(필요 시 allowedHosts 설정).

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] Merge 대상 브랜치가 올바른가?
- [x] 코드가 정상적으로 빌드되는가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?
- [ ] 관련 테스트 코드를 작성했는가?
- [ ] 기존 테스트가 모두 통과하는가?
- [x] 코드 스타일(ESLint, Prettier)을 준수하는가?

## 📌 참고 사항

	•	(로컬 테스트) Cloudflare Tunnel로 카카오 인앱 브라우저 테스트 시
	•	cloudflared tunnel --url http://localhost:3000 --protocol http2 권장(QUIC 불안정 시)
	•	Vite에서 host 차단이 발생하면 server.allowedHosts: ['.trycloudflare.com'] 설정 필요