### PR TITLE
[Feat] 관리자 로그인 후 /admin으로 리다이렉트 구현

### DIFF
--- a/src/pages/login/cookie.tsx
+++ b/src/pages/login/cookie.tsx
@@ -34,7 +34,7 @@ export default function CookiePage() {
     // 이미 토큰이 저장된 상태면(이중 호출/새로고침 등) 바로 리다이렉트
     const existingAccess = sessionStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
     if (existingAccess) {
-      performRedirect(existingAccess ?? undefined);
+      performRedirect(existingAccess);
       return;
     }
 


### PR DESCRIPTION
## 🍀 이슈 번호

<!-- 이슈 번호를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #77 

---

## 📝 변경 사항

	•	로그인 완료 처리 지점(/cookie 페이지)에서 role 기반 리다이렉트 분기 로직 추가
	•	parseAccessToken을 활용하여 accessToken에서 role 파싱
	•	ADMIN 사용자의 경우 로그인 직후 /admin으로 자동 이동하도록 개선
	•	일반 사용자는 기존대로 postLoginRedirect 또는 기본 경로(/apply)로 이동 유지

## 🎯 목적

현재는 로그인 완료 후 항상 postLoginRedirect 또는 기본 경로로 이동하고 있습니다.
그러나 ADMIN 사용자의 경우 로그인 직후 관리자 대시보드(/admin)로 자동 이동하는 것이 UX 측면에서 더 자연스럽습니다.

이번 변경을 통해:
	•	인증 가드(RequireAuth)는 순수하게 “로그인 여부 확인” 역할만 수행
	•	권한 기반 초기 동선은 로그인 처리 로직에서 담당
	•	로그인 플로우와 권한 정책의 책임이 명확하게 분리됨
	•	Auth Flow 구조가 더 일관되고 예측 가능해짐

## 📂 적용 범위

	•	src/pages/login/cookie.tsx

---

## 💬 리뷰어에게

	•	인증 가드와 권한 기반 초기 동선을 분리하여 책임을 명확히 했습니다.
	•	로그인 시점에서만 ADMIN 분기가 일어나도록 설계하여, 가드 내부에 불필요한 상태 플래그가 남지 않도록 정리했습니다.
	•	추가적인 role이 확장될 경우에도 로그인 시점에서 분기 확장이 용이합니다.

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] Merge 대상 브랜치가 올바른가?
- [x] 코드가 정상적으로 빌드되는가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?
- [ ] 관련 테스트 코드를 작성했는가?
- [ ] 기존 테스트가 모두 통과하는가?
- [x] 코드 스타일(ESLint, Prettier)을 준수하는가?
