### PR TITLE
[FIX] GHCR 이미지 빌드 시 대문자 태그 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,6 +143,10 @@ jobs:
           name: deploy-artifact
           path: dist
 
+      # Docker IMAGE_NAME을 소문자로 변환
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 


### PR DESCRIPTION
- 도커 이미지 이름이 소문자여야 하는 규칙에 맞춰 이미지 이름을 강제로 소문자로 변환하는 스텝 추가

---

## 📝 변경 사항

- .github/workflows/deploy.yml 파일 내 도커 이미지 빌드 전 IMAGE_NAME 환경변수를 소문자로 강제 변환하는 스텝 추가

## 🎯 목적

- GitHub Actions 환경변수(github.repository_owner)가 대문자를 포함하여 반환될 경우 발생하는 도커 이미지 태그 생성 에러(invalid reference format) 해결
- 도커 레지스트리 소문자 명명 규칙 준수

## 적용 범위

- .github/workflows/deploy.yml

---

## 주요 코드 설명

```yaml
- name: Set lowercase image name
  run: echo "IMAGE_NAME=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV

```

## 💬 리뷰어에게

- 백엔드 저장소의 배포 워크플로우와 동일한 방식으로 문제를 해결하여 스크립트 일관성을 맞추었습니다. Merge 후 Actions 배포 파이프라인이 정상 작동하는지 확인 부탁드립니다.

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [X] Merge 대상 브랜치가 올바른가?
- [X] 코드가 정상적으로 빌드되는가?
- [X] 최종 코드가 에러 없이 잘 동작하는가?
- [X] 전체 변경사항이 500줄을 넘지 않는가?
- [ ] 관련 테스트 코드를 작성했는가?
- [X] 기존 테스트가 모두 통과하는가?
- [X] 코드 스타일(ESLint, Prettier)을 준수하는가?

## 📌 참고 사항

- 백엔드 CI/CD 워크플로우 로직 차용