### PR TITLE
[FIX] 도커 빌드 시 dist 폴더 누락 문제 해결 (.dockerignore 수정)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 node_modules
-dist
 .git
 .env
 .DS_Store


### PR DESCRIPTION
- 도커 빌드 시 dist 폴더 누락 문제 해결

---

## 📝 변경 사항

- `.dockerignore` 파일 내 `dist` 폴더 제외(ignore) 규칙 주석 처리(또는 삭제)

## 🎯 목적

- GitHub Actions 도커 이미지 빌드 단계에서 `dist` 폴더가 빌드 컨텍스트에서 제외되어 발생하는 `COPY failed: "/dist": not found` 에러 해결
- Integrate 단계에서 생성된 프론트엔드 아티팩트(`dist`)가 Nginx 도커 이미지 내부에 정상적으로 복사되도록 컨텍스트 접근 허용

## 📂 적용 범위

- `.dockerignore`

---

## 🖥️ 주요 코드 설명

```text
node_modules
# dist  <-- 빌드 컨텍스트에 포함되도록 삭제
.git
.env
.DS_Store
coverage
```

## 💬 리뷰어에게

- 이전 배포 실패의 원인이었던 .dockerignore의 dist 폴더 차단 규칙을 해제했습니다. Merge 후 Actions 배포 파이프라인에서 Build Image 단계가 정상적으로 통과하는지 확인 부탁드립니다.

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [X] Merge 대상 브랜치가 올바른가?
- [X] 코드가 정상적으로 빌드되는가?
- [X] 최종 코드가 에러 없이 잘 동작하는가?
- [X] 전체 변경사항이 500줄을 넘지 않는가?
- [ ] 관련 테스트 코드를 작성했는가?
- [X] 기존 테스트가 모두 통과하는가?
- [X] 코드 스타일(ESLint, Prettier)을 준수하는가?

## 📌 참고 사항

- 빌드에 필요한 결과물 디렉터리가 도커 컨텍스트에 온전히 전달되도록 수정된 사항입니다.