### PR TITLE
[FIX] 프론트엔드 빌드 시 VITE_BACKEND_API_BASE_URL 환경변수 주입 누락 수정

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -307,7 +307,7 @@ jobs:
 
       - name: Build
         env:
-          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          VITE_BACKEND_API_BASE_URL: ${{ vars.VITE_BACKEND_API_BASE_URL }}
         run: npm run build
 
       - name: Upload Build Artifact


### PR DESCRIPTION
## 📝 변경 사항

- `.github/workflows/integrate.yml` 파일 내 `build` Job 스텝에 `VITE_BACKEND_API_BASE_URL` 환경변수 주입 추가

## 🎯 목적

- 배포 파이프라인이 레포지토리 기반에서 GHCR(GitHub Actions 빌드) 기반으로 전환됨에 따라, 프론트엔드 빌드 시점에 백엔드 API 주소 환경변수가 정상적으로 포함되도록 수정하여 API 호출 실패 문제 해결

## 📂 적용 범위

- `.github/workflows/integrate.yml`

---

## 🖥️ 주요 코드 설명

```yaml
      - name: Build
        env:
          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
          VITE_BACKEND_API_BASE_URL: ${{ vars.VITE_BACKEND_API_BASE_URL }}
        run: npm run build
```

## 💬 리뷰어에게

- GHCR 기반 배포로 넘어가면서 발생한 환경변수 빌드 타임 주입 누락 건을 수정했습니다. Merge 후 워크플로우가 완료되면 프론트엔드 웹에서 백엔드 API로 요청이 정상적으로 들어가는지 확인 부탁드립니다.

---

## 📋 체크리스트

- [X] Merge 대상 브랜치가 올바른가?
- [X] 코드가 정상적으로 빌드되는가?
- [X] 최종 코드가 에러 없이 잘 동작하는가?
- [X] 전체 변경사항이 500줄을 넘지 않는가?
- [ ] 관련 테스트 코드를 작성했는가?
- [X] 기존 테스트가 모두 통과하는가?
- [X] 코드 스타일(ESLint, Prettier)을 준수하는가?

## 📌 참고 사항

- 이 변경 사항이 정상적으로 작동하려면 GitHub Repository의 Settings > Secrets and variables > Actions > Variables에 VITE_BACKEND_API_BASE_URL 값이 반드시 등록되어 있어야 합니다.
