### PR TITLE
[FIX] entrypoint.sh 줄바꿈 형식 오류(exec format error) 해결

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -8,7 +8,7 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # entrypoint.sh 복사 및 실행 권한 부여
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
 EXPOSE 80
 


### PR DESCRIPTION
- Windows 환경에서 작성된 스크립트의 CRLF 줄바꿈을 Linux용 LF로 강제 변환
- Dockerfile.deploy 내에 sed 명령어를 추가하여 도커 컨테이너 실행 에러 방지

---

## 📝 변경 사항

- `Dockerfile.deploy` 파일 내에 `entrypoint.sh`의 Windows식 줄바꿈(CRLF)을 Linux식(LF)으로 강제 변환하는 명령어 추가
- 도커 컨테이너 실행 시 발생하는 `exec format error` 방지 로직 적용

## 🎯 목적

Windows 환경에서 `entrypoint.sh` 스크립트 파일을 생성하거나 수정할 경우, 눈에 보이지 않는 캐리지 리턴(`\r`, CRLF) 문자가 포함되어 저장됩니다. 이로 인해 Linux 기반인 Docker 컨테이너가 스크립트의 첫 줄(`#!/bin/sh\r`)을 정상적으로 해석하지 못하고 `exec /entrypoint.sh: exec format error`를 발생시키며 컨테이너가 종료되는 치명적인 문제가 있었습니다.

이를 해결하기 위해, 도커 이미지를 굽는(Build) 단계에서 스크립트 내의 \r 문자를 강제로 제거하여 OS 환경에 상관없이 안정적으로 배포가 진행되도록 개선했습니다.

## 📂 적용 범위

- `Dockerfile.deploy`

---

## 🖥️ 주요 코드 설명

```Dockerfile
# /entrypoint.sh 복사 후, sed 명령어를 통해 윈도우 줄바꿈 문자(\r)를 찾아 빈 문자열로 치환(삭제)합니다.
# 그 이후에 컨테이너가 스크립트를 실행할 수 있도록 chmod로 실행 권한을 부여합니다.
RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
```

## 💬 리뷰어에게

- 프론트엔드 환경변수 런타임 주입 기능(entrypoint) 도입 후, 배포 과정에서 발생한 컨테이너 실행 에러를 긴급 수정한 핫픽스 성격의 PR입니다.
- 인프라(Docker) 설정 변경이므로 가볍게 확인 후 머지 부탁드립니다!

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [X] Merge 대상 브랜치가 올바른가?
- [X] 코드가 정상적으로 빌드되는가?
- [X] 최종 코드가 에러 없이 잘 동작하는가?
- [X] 전체 변경사항이 500줄을 넘지 않는가?
- [ ] 관련 테스트 코드를 작성했는가?
- [X] 기존 테스트가 모두 통과하는가?
- [X] 코드 스타일(ESLint, Prettier)을 준수하는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
